### PR TITLE
Fix Build Warning to eliminate confusion.

### DIFF
--- a/clientbuffer.cpp
+++ b/clientbuffer.cpp
@@ -43,7 +43,7 @@ public:
     void OnDelClientCommand(const CString& line);
     void OnListClientsCommand(const CString& line);
 
-    virtual void OnClientLogin();
+    virtual void OnClientLogin() override;
 
     virtual EModRet OnUserRaw(CString& line) override;
     virtual EModRet OnSendToClient(CString& line, CClient& client) override;


### PR DESCRIPTION
Fix Build warning when compiling with znc-buildmod. Will reduce confusion with new users, and confidence of users.